### PR TITLE
fix mini apple button icon

### DIFF
--- a/lib/src/social_button.dart
+++ b/lib/src/social_button.dart
@@ -42,7 +42,7 @@ class FlutterSocialButton extends StatelessWidget {
             ? ElevatedButton(
                 onPressed: onTap,
                 child: Icon(
-                  FontAwesomeIcons.facebookF,
+                  FontAwesomeIcons.apple,
                   color: iconColor,
                 ),
                 style: ElevatedButton.styleFrom(


### PR DESCRIPTION
The previous icon for `apple` was set as `FontAwesomeIcons.facebookF`.

```dart
...

child: Icon(
      FontAwesomeIcons.apple,
      color: iconColor,
    ),

...

```

✌🏾