### PR TITLE
Change Icon usage to FaIcon

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -21,26 +21,26 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -53,10 +53,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -86,34 +86,34 @@ packages:
     dependency: transitive
     description:
       name: font_awesome_flutter
-      sha256: d3a89184101baec7f4600d58840a764d2ef760fe1c5a20ef9e6b0e9b24a07a3a
+      sha256: "09dcde8ab90ffae1a7d65ff2ef96fc62a17ad9d0ce7c127b317ded676b0d5935"
       url: "https://pub.dev"
     source: hosted
-    version: "10.8.0"
+    version: "11.0.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.5"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.5"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -126,39 +126,39 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   sky_engine:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.99"
+    version: "0.0.0"
   source_span:
     dependency: transitive
     description:
@@ -171,18 +171,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.1"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -203,18 +203,18 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.2"
+    version: "0.7.10"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -224,5 +224,5 @@ packages:
     source: hosted
     version: "14.2.5"
 sdks:
-  dart: ">=3.5.0 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.27.0"

--- a/lib/src/widgets/social_login_button.dart
+++ b/lib/src/widgets/social_login_button.dart
@@ -206,42 +206,42 @@ class FlutterSocialButton extends StatelessWidget {
 
         /// If no customIcon is provided, return the Facebook icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.facebookF, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.facebookF, color: iconColor, size: iconSize);
       case ButtonType.google:
 
         /// Return the Google icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.google, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.google, color: iconColor, size: iconSize);
       case ButtonType.twitter:
 
         /// Return the Twitter icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.twitter, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.twitter, color: iconColor, size: iconSize);
       case ButtonType.linkedin:
 
         /// Return the LinkedIn icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.linkedin, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.linkedin, color: iconColor, size: iconSize);
       case ButtonType.whatsapp:
 
         /// Return the WhatsApp icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.whatsapp, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.whatsapp, color: iconColor, size: iconSize);
       case ButtonType.apple:
 
         /// Return the Apple icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.apple, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.apple, color: iconColor, size: iconSize);
       case ButtonType.github:
 
         /// Return the GitHub icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.github, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.github, color: iconColor, size: iconSize);
       case ButtonType.yahoo:
 
         /// Return the Yahoo icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.yahoo, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.yahoo, color: iconColor, size: iconSize);
       case ButtonType.phone:
 
         /// Return the Phone icon using Flutter's built-in icon with the specified color and size.
@@ -255,32 +255,32 @@ class FlutterSocialButton extends StatelessWidget {
 
         /// Return the Instagram icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.instagram, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.instagram, color: iconColor, size: iconSize);
       case ButtonType.youtube:
 
         /// Return the YouTube icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.youtube, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.youtube, color: iconColor, size: iconSize);
       case ButtonType.snapchat:
 
         /// Return the Snapchat icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.snapchat, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.snapchat, color: iconColor, size: iconSize);
       case ButtonType.pinterest:
 
         /// Return the Pinterest icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.pinterest, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.pinterest, color: iconColor, size: iconSize);
       case ButtonType.tiktok:
 
         /// Return the TikTok icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.tiktok, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.tiktok, color: iconColor, size: iconSize);
       case ButtonType.reddit:
 
         /// Return the Reddit icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(
+            FaIcon(
               FontAwesomeIcons.redditAlien,
               color: iconColor,
               size: iconSize,
@@ -289,57 +289,57 @@ class FlutterSocialButton extends StatelessWidget {
 
         /// Return the Tumblr icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.tumblr, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.tumblr, color: iconColor, size: iconSize);
       case ButtonType.skype:
 
         /// Return the Skype icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.skype, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.skype, color: iconColor, size: iconSize);
       case ButtonType.viber:
 
         /// Return the Viber icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.viber, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.viber, color: iconColor, size: iconSize);
       case ButtonType.discord:
 
         /// Return the Discord icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.discord, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.discord, color: iconColor, size: iconSize);
       case ButtonType.wechat:
 
         /// Return the WeChat icon (weixin) from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.weixin, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.weixin, color: iconColor, size: iconSize);
       case ButtonType.line:
 
         /// Return the Line icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.line, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.line, color: iconColor, size: iconSize);
       case ButtonType.quora:
 
         /// Return the Quora icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.quora, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.quora, color: iconColor, size: iconSize);
       case ButtonType.twitch:
 
         /// Return the Twitch icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.twitch, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.twitch, color: iconColor, size: iconSize);
       case ButtonType.flickr:
 
         /// Return the Flickr icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.flickr, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.flickr, color: iconColor, size: iconSize);
       case ButtonType.yelp:
 
         /// Return the Yelp icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.yelp, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.yelp, color: iconColor, size: iconSize);
       case ButtonType.spotify:
 
         /// Return the Spotify icon from FontAwesome with the specified color and size.
         return icon ??
-            Icon(FontAwesomeIcons.spotify, color: iconColor, size: iconSize);
+            FaIcon(FontAwesomeIcons.spotify, color: iconColor, size: iconSize);
       case ButtonType.website:
 
         /// Return the Website icon using Flutter's built-in icon with the specified color and size.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  font_awesome_flutter: ^10.8.0
+  font_awesome_flutter: ^11.0.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_social_button
 description: Flutter Social Button is a flutter package to create social media login buttons easily to any flutter app.
-version: 1.1.6+1
+version: 1.1.7
 homepage: https://github.com/alok2811/flutter_social_button
 
 environment:


### PR DESCRIPTION
## Description
With the change to [Mark `IconData` as `final`](https://github.com/flutter/flutter/issues/181342) that landed on April 2, 2026, `FlutterSocialButton` breaks builds due to the use of [`font_awesome_flutter`](https://pub.dev/packages/font_awesome_flutter) version `^10.8.0`. Version `11.0.0` of `font_awesome_flutter` fixes the breaking change and thus the fix to the breaking change is to update the dependency to that version.

Build error message:
> ../../../.pub-cache/hosted/pub.dev/font_awesome_flutter-10.12.0/lib/src/icon_data.dart:17:29: Error: The class 'IconData' can't be extended outside of its library because it's a final class.
class IconDataSolid extends IconData {

In order to support this version of `font_awesome_flutter`, it is necessary to change the return type of most icons from `Icon` to [`FaIcon`](https://github.com/fluttercommunity/font_awesome_flutter/blob/master/lib/src/fa_icon.dart).